### PR TITLE
Update README to be Open Home Foundation centric

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
-<img src="https://www.home-assistant.io/images/home-assistant-logo.svg" alt="Home Assistant Logo" />
+# Open Home Foundation Roadmap
 
-# Home Assistant Roadmap
+Welcome! This is the official roadmap repository for [Home Assistant](https://www.home-assistant.io/), [ESPHome](https://esphome.io/), [Music Assistant](https://music-assistant.io/), and other Open Home Foundation projects, maintained by the [Open Home Foundation](https://www.openhomefoundation.org/).
 
-Welcome! This is the official roadmap repository for Home Assistant, maintained by the [Open Home Foundation](https://www.openhomefoundation.org/).
-
-This repository tracks strategic opportunities, initiatives, and development areas for the Home Assistant project. The roadmap is managed by the Open Home Foundation product team, who monitor community feature requests and translate them into actionable opportunities.
+This repository tracks strategic opportunities, initiatives, and development areas across Open Home Foundation projects. The roadmap is managed by the Open Home Foundation product team, who monitor community feature requests and translate them into actionable opportunities.
 
 > [!IMPORTANT]
 > **This repository is restricted to Open Home Foundation staff and authorized contributors only.**
 >
-> Community members should submit feature requests to the [Feature Requests repository](https://github.com/home-assistant/feature-requests), where they will be reviewed by the product team and potentially incorporated into roadmap opportunities.
+> Community members should submit feature requests to the appropriate project repository listed below, where they will be reviewed by the product team and potentially incorporated into roadmap opportunities.
 >
 > For bug reports or support, please use the appropriate issue tracker listed below.
 
-Looking to report a bug or request a feature instead?
+## Home Assistant
+
+Looking to report a bug or request a feature for Home Assistant?
 
 Please use the correct repository depending on the type of request:
 
@@ -26,17 +26,35 @@ Please use the correct repository depending on the type of request:
 - [Supervisor](https://github.com/home-assistant/supervisor/issues)
 - [Add-ons](https://github.com/home-assistant/addons/issues)
 
-Still have questions? Ask in our [Discord chat](https://discord.gg/home-assistant) — the community is happy to help.
+Still have questions? Ask in our [Home Assistant Discord chat](https://discord.gg/home-assistant) — the community is happy to help.
+
+## ESPHome
+
+Looking to report a bug or request a feature for ESPHome?
+
+- [Feature Requests](https://github.com/orgs/esphome/discussions) – for feature suggestions and ideas
+- [ESPHome](https://github.com/esphome/esphome/issues) – for bug reports
+
+Still have questions? Ask in our [ESPHome Discord chat](https://discord.gg/KhAMKrd) — the community is happy to help.
+
+## Music Assistant
+
+Looking to report a bug or request a feature for Music Assistant?
+
+- [Feature Requests](https://github.com/orgs/music-assistant/discussions) – for feature suggestions and ideas
+- [Support](https://github.com/music-assistant/support/issues) – for bug reports
+
+Still have questions? Ask in our [Music Assistant Discord chat](https://discord.gg/kaVm8hGpne) — the community is happy to help.
 
 ## 🚀 How the Roadmap Works
 
-The Home Assistant roadmap is curated by the Open Home Foundation product team through the following process:
+The Open Home Foundation roadmap is curated by the product team through the following process:
 
 ### For Community Members
 
-**Want to influence the roadmap?** Submit your ideas to the [Feature Requests repository](https://github.com/home-assistant/feature-requests/discussions)!
+**Want to influence the roadmap?** Submit your ideas to the feature requests repository of the relevant project!
 
-1. **Submit Feature Requests**: Share your ideas and use cases in the Feature Requests repository
+1. **Submit Feature Requests**: Share your ideas and use cases in the appropriate project's feature requests repository
 2. **Vote and Discuss**: Support existing requests and add your perspective
 3. **Product Team Review**: The product team regularly reviews popular and strategic feature requests
 4. **Roadmap Creation**: Selected features are translated into roadmap opportunities by the product team
@@ -48,21 +66,22 @@ The Home Assistant roadmap is curated by the Open Home Foundation product team t
 
 If you are authorized to create opportunities:
 
-1. First, [search the existing issues](https://github.com/home-assistant/roadmap/issues) to see if a similar opportunity exists
-2. [Create a new issue](https://github.com/home-assistant/roadmap/issues/new/choose) using the "Roadmap Opportunity" template
-3. Fill in all sections with detailed information:
-   - **Goals**: Clearly describe the opportunity and its rationale
-   - **Vision**: Provide a detailed description of what you want to achieve
-   - **Scope & Boundaries**: Define what's included and what's explicitly out of scope
-   - **Plan**: Outline how to achieve the vision, including epic breakdown and prioritization
-   - **Decision Log**: Document key decisions made during planning
-   - **Q&A**: Address common questions that may arise
+1. First, [search the existing issues](https://github.com/OpenHomeFoundation/roadmap/issues) to see if a similar opportunity exists
+2. [Create a new issue](https://github.com/OpenHomeFoundation/roadmap/issues/new/choose) using the "Roadmap Opportunity" template
+3. Fill in all sections with as much detail as you have — not every field is required at every stage:
+   - **Problem Statement**: Describe the problem, who is impacted, and why it matters
+   - **Community Signals**: Link to feature requests, discussions, or other signals that informed the item
+   - **Scope & Boundaries**: Define what's in scope and what's explicitly out of scope
+   - **Foreseen Solution**: Describe the solution at a high level, shaped enough to understand what it means to build
+   - **Risks & Open Questions**: Call out technical, UX, or strategic uncertainties
+   - **Appetite**: Rough sizing of how much time we're willing to invest (small / medium / large)
+   - **Decision Log**: Record key decisions, pivots, and betting table outcomes with dates
 
 ## 📋 Roadmap Process
 
 The Open Home Foundation manages roadmap opportunities through this structured process:
 
-1. **Community Input**: Feature requests are collected and discussed in the [Feature Requests repository](https://github.com/home-assistant/feature-requests)
+1. **Community Input**: Feature requests are collected and discussed in the relevant project repositories
 2. **Product Team Review**: The product team regularly reviews feature requests for strategic alignment and feasibility
 3. **Opportunity Creation**: Selected features are formulated into roadmap opportunities by authorized team members
 4. **Planning & Refinement**: Opportunities are refined with detailed scope, epics, and implementation plans
@@ -73,7 +92,7 @@ The Open Home Foundation manages roadmap opportunities through this structured p
 
 - Roadmap opportunities should be significant strategic initiatives, not individual features
 - Proposals should align with our [values](https://www.openhomefoundation.org/): local control, privacy, choice, and sustainability
-- Home Assistant is an open source project powered by volunteers and contributors working in their spare time
+- Open Home Foundation projects are open source, powered by volunteers and contributors working in their spare time
 - Please respect everyone involved, and be mindful of the time and energy others have invested
 - This space is covered by our [Code of Conduct](https://www.home-assistant.io/code_of_conduct/)
 - Opportunities should be realistic, actionable, and well-scoped
@@ -86,11 +105,11 @@ View our active roadmap opportunities and their progress on our [Project Board](
 
 ## 💬 Get involved
 
-Want to help shape the future of Home Assistant? Here's how:
+Want to help shape the future of Open Home Foundation projects? Here's how:
 
-- **Submit Feature Requests**: Share your ideas in the [Feature Requests repository](https://github.com/home-assistant/feature-requests)
+- **Submit Feature Requests**: Share your ideas in the relevant project's feature requests repository
 - **Vote and Discuss**: Support feature requests that align with your needs
-- **Contribute Code**: Help implement roadmap opportunities by contributing to the [Home Assistant repositories](https://github.com/home-assistant)
+- **Contribute Code**: Help implement roadmap opportunities by contributing to [Home Assistant](https://github.com/home-assistant), [ESPHome](https://github.com/esphome), or [Music Assistant](https://github.com/music-assistant)
 - **Follow Progress**: Watch this repository to stay updated on roadmap developments
 
 Remember: The roadmap is driven by community needs! Your feature requests directly influence what the product team prioritizes.


### PR DESCRIPTION
## Summary

- Reframes the README around the Open Home Foundation rather than Home Assistant alone
- Adds dedicated sections for ESPHome and Music Assistant with feature request, bug report, and Discord links
- Updates all `home-assistant/roadmap` links to `OpenHomeFoundation/roadmap`

## Test plan

- [ ] Verify all links are correct and point to the right repositories
- [ ] Check that ESPHome, Music Assistant, and Home Assistant sections are accurate